### PR TITLE
Fixed DynamoDB table naming error. 

### DIFF
--- a/lib/models/team.js
+++ b/lib/models/team.js
@@ -12,7 +12,7 @@ var dynamoConfig = {
   region:          process.env.AWS_REGION
 };
 var dynamodbDocClient = new AWS.DynamoDB.DocumentClient(dynamoConfig);
-var tableName = 'serverless-slackbot-teams-' + process.env.SERVERLESS_DATA_MODEL_STAGE;
+var tableName = 'serverless-slack-teams-' + process.env.SERVERLESS_DATA_MODEL_STAGE;
 
 /**
  * Team Class


### PR DESCRIPTION
Base table name in s-module.json is 'serverless-slack-teams' whereas team.js attempts to put to 'serverless-slackbot-teams'
